### PR TITLE
hacks to compile on Ubuntu 22.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ cscope.*
 tags
 TAGS
 *~
+
+/bin/
+/etc/
+/libexec/
+/share/
+/tests/qemu-iotests/common.env

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+git checkout xtensa-esp8266
+export QEMU=`pwd`
+./configure --prefix=$QEMU --target-list=xtensa-softmmu --disable-werror
+make
+make install

--- a/hw/xtensa/xtfpga.c
+++ b/hw/xtensa/xtfpga.c
@@ -444,7 +444,7 @@ static void lx_init(const LxBoardDesc *board, MachineState *machine)
         }
         if (dtb_filename) {
             int fdt_size;
-            void *fdt = load_device_tree(dtb_filename, &fdt_size);
+            void *fdt = NULL; //load_device_tree(dtb_filename, &fdt_size);
             uint32_t dtb_addr = tswap32(cur_lowmem);
 
             if (!fdt) {

--- a/qga/commands-posix.c
+++ b/qga/commands-posix.c
@@ -28,6 +28,7 @@
 #include "qapi/qmp/qerror.h"
 #include "qemu/queue.h"
 #include "qemu/host-utils.h"
+#include <sys/sysmacros.h>
 
 #ifndef CONFIG_HAS_ENVIRON
 #ifdef __APPLE__

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+export QEMU=`pwd`
+$QEMU/bin/qemu-system-xtensa -M esp8266 -nographic -serial stdio -monitor none -kernel $1
+#$QEMU/bin/qemu-system-xtensa -M esp8266 -nographic -serial stdio -monitor none -s -S -kernel /path/to/build/dir/esp8266flash.bin
+#xtensa-esp8266-elf-gdb /path/to/build/dir/image.elf
+#(gdb) target remote :1234


### PR DESCRIPTION
* build and run script
* remove load_device_tree
* add sys/sysmacros.h

*DO NOT MERGE*
This is only to enable users of modern linux compile the code